### PR TITLE
Fix race condition with concurrent connection attempts

### DIFF
--- a/src/generated.rs
+++ b/src/generated.rs
@@ -745,8 +745,8 @@ impl Channel {
         if level_enabled!(Level::TRACE) {
             promise.set_marker("basic.ack".into());
         }
-        self.send_method_frame(method, send_resolver, None);
         self.on_basic_ack_sent(multiple, delivery_tag);
+        self.send_method_frame(method, send_resolver, None);
         promise.await
     }
     fn receive_basic_ack(&self, method: protocol::basic::Ack) -> Result<()> {
@@ -793,8 +793,8 @@ impl Channel {
         if level_enabled!(Level::TRACE) {
             promise.set_marker("basic.recover-async".into());
         }
-        self.send_method_frame(method, send_resolver, None);
         self.on_basic_recover_async_sent();
+        self.send_method_frame(method, send_resolver, None);
         promise.await
     }
     pub async fn basic_recover(&self, options: BasicRecoverOptions) -> Result<()> {
@@ -869,8 +869,8 @@ impl Channel {
         if level_enabled!(Level::TRACE) {
             promise.set_marker("basic.nack".into());
         }
-        self.send_method_frame(method, send_resolver, None);
         self.on_basic_nack_sent(multiple, delivery_tag);
+        self.send_method_frame(method, send_resolver, None);
         promise.await
     }
     fn receive_basic_nack(&self, method: protocol::basic::Nack) -> Result<()> {
@@ -913,8 +913,8 @@ impl Channel {
         if level_enabled!(Level::TRACE) {
             promise.set_marker("connection.start-ok".into());
         }
-        self.send_method_frame(method, send_resolver, None);
         self.on_connection_start_ok_sent(resolver, connection, credentials);
+        self.send_method_frame(method, send_resolver, None);
         promise.await
     }
     fn receive_connection_secure(&self, method: protocol::connection::Secure) -> Result<()> {
@@ -998,6 +998,7 @@ impl Channel {
         if level_enabled!(Level::TRACE) {
             promise.set_marker("connection.open.Ok".into());
         }
+        self.on_connection_open_sent(conn_resolver);
         self.send_method_frame(
             method,
             send_resolver,
@@ -1006,7 +1007,6 @@ impl Channel {
                 Box::new(resolver),
             )),
         );
-        self.on_connection_open_sent(conn_resolver);
         promise_out.await?;
         promise.await
     }
@@ -1093,8 +1093,8 @@ impl Channel {
         if level_enabled!(Level::TRACE) {
             promise.set_marker("connection.close-ok".into());
         }
-        self.send_method_frame(method, send_resolver, None);
         self.on_connection_close_ok_sent(error);
+        self.send_method_frame(method, send_resolver, None);
         promise.await
     }
     fn receive_connection_close_ok(&self, method: protocol::connection::CloseOk) -> Result<()> {
@@ -1406,8 +1406,8 @@ impl Channel {
         if level_enabled!(Level::TRACE) {
             promise.set_marker("channel.close-ok".into());
         }
-        self.send_method_frame(method, send_resolver, None);
         self.on_channel_close_ok_sent(error);
+        self.send_method_frame(method, send_resolver, None);
         promise.await
     }
     fn receive_channel_close_ok(&self, method: protocol::channel::CloseOk) -> Result<()> {

--- a/templates/channel.rs
+++ b/templates/channel.rs
@@ -130,11 +130,10 @@ impl Channel {
     }
     {{/if ~}}
     {{#if method.metadata.resolver_hook ~}}{{method.metadata.resolver_hook}}{{/if ~}}
-    self.send_method_frame(method, send_resolver, {{#if method.synchronous ~}}Some(ExpectedReply(Reply::{{camel class.name}}{{camel method.name}}Ok(resolver.clone(){{#if method.metadata.state ~}}{{#each method.metadata.state as |state| ~}}, {{#if state.provider}}{{state.provider}}{{else}}{{state.name}}{{#if state.use_str_ref ~}}.into(){{/if ~}}{{/if ~}}{{/each ~}}{{/if ~}}), Box::new(resolver))){{else}}None{{/if ~}});
     {{#if method.metadata.end_hook ~}}
     self.on_{{snake class.name false}}_{{snake method.name false}}_sent({{#if method.metadata.end_hook.params ~}}{{#each method.metadata.end_hook.params as |param| ~}}{{#unless @first ~}}, {{/unless ~}}{{param}}{{/each ~}}{{/if ~}});
     {{/if ~}}
-
+    self.send_method_frame(method, send_resolver, {{#if method.synchronous ~}}Some(ExpectedReply(Reply::{{camel class.name}}{{camel method.name}}Ok(resolver.clone(){{#if method.metadata.state ~}}{{#each method.metadata.state as |state| ~}}, {{#if state.provider}}{{state.provider}}{{else}}{{state.name}}{{#if state.use_str_ref ~}}.into(){{/if ~}}{{/if ~}}{{/each ~}}{{/if ~}}), Box::new(resolver))){{else}}None{{/if ~}});
     {{#if method.synchronous ~}}
     {{#if method.metadata.nowait_hook ~}}
     if nowait {


### PR DESCRIPTION
Hello :wave:

I think I found a race condition that happens when you try to open a lot of concurrent connections at once.

I was working on an application that uses `lapin`, where there are quite a few tests that run concurrently (and each test connects to Rabibt using `lapin`), but sometimes I got spurious connection issues in CI, in particular, `lapin::Connection::connect` sometimes just hanged.

After a bit of debugging, I discovered that the hang was caused by a `pinky::Pinky` inside the `ConnectionStep` being dropped without being resolved. This happened both [here](https://github.com/amqp-rs/lapin/blob/491114224430a7b9460a924ca179280a294f0fc4/src/channel.rs#L761) and [here](https://github.com/amqp-rs/lapin/blob/491114224430a7b9460a924ca179280a294f0fc4/src/channel.rs#L781) (randomly). For some reason that's still not 100% clear to me, the `ConnectionStep` has the wrong value and the resolver gets silently dropped.

My guess is that when we enqueue a frame to be sent to the server (like [here](https://github.com/amqp-rs/lapin/blob/491114224430a7b9460a924ca179280a294f0fc4/src/generated.rs#L916)) for some reason, sometimes, this triggers a **synchronous** chain of calls that causes the next handler down the chain to see an invalid `ConnectionStep`. I'm absolutely not sure this is the correct root cause, this is just a wild guess, but updating the `ConnectionStep` before enqueuing the write actually solves the issue.

I'm not sure of the implications of this change, also because changing the template file also changed other code paths like for `basic.ack` and `basic.nack` that are not related to the initial phases of the connection.

If you want to try reproducing the race by yourself, I've written a [small binary](https://gist.github.com/95ulisse/a536e2927026c9f147d074593eb5d246) that attempts 100 concurrent connections for 100 times, just to stress test the library.

Thank you!