### PR TITLE
move async-std default runtime into a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ build = "build.rs"
 rust-version = "1.56.0"
 
 [features]
-default                   = ["rustls"]
+default                   = ["rustls", "default-runtime"]
+default-runtime           = ["async-global-executor-trait", "async-reactor-trait"]
 codegen                   = ["codegen-internal", "amq-protocol/codegen"]
 codegen-internal          = ["amq-protocol-codegen", "serde_json"]
 native-tls                = ["amq-protocol/native-tls"]
@@ -39,6 +40,11 @@ default-features = false
 [dependencies.async-global-executor-trait]
 version = "^2.1"
 features = ["async-io"]
+optional = true
+
+[dependencies.async-reactor-trait]
+version = "^1.1"
+optional = true
 
 [dependencies.flume]
 version = "^0.10"
@@ -54,7 +60,6 @@ version = "^0.1"
 default-features = false
 
 [dependencies]
-async-reactor-trait = "^1.1"
 async-trait = "^0.1.42"
 executor-trait = "^2.1"
 futures-core = "^0.3"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -292,10 +292,15 @@ impl Connection {
         connect: Box<dyn FnOnce(&AMQPUri) -> HandshakeResult + Send + Sync>,
         mut options: ConnectionProperties,
     ) -> Result<Connection> {
-        let executor = options
-            .executor
-            .take()
-            .unwrap_or_else(|| Arc::new(async_global_executor_trait::AsyncGlobalExecutor));
+        let executor = options.executor.take();
+
+        #[cfg(feature = "default-runtime")]
+        let executor =
+            executor.unwrap_or_else(|| Arc::new(async_global_executor_trait::AsyncGlobalExecutor));
+
+        #[cfg(not(feature = "default-runtime"))]
+        let executor = executor
+            .expect("executor should be provided with no default executor feature was enabled");
 
         let (connect_promise, resolver) = pinky_swear::PinkySwear::<Result<TcpStream>>::new();
         let connect_uri = uri.clone();
@@ -327,10 +332,15 @@ impl Connection {
             })
         });
 
-        let reactor = options
-            .reactor
-            .take()
-            .unwrap_or_else(|| Arc::new(async_reactor_trait::AsyncIo));
+        let reactor = options.reactor.take();
+
+        #[cfg(feature = "default-runtime")]
+        let reactor = reactor.unwrap_or_else(|| Arc::new(async_reactor_trait::AsyncIo));
+
+        #[cfg(not(feature = "default-runtime"))]
+        let reactor = reactor
+            .expect("reactor should be provided with no default reactor feature was enabled");
+
         let socket_state = SocketState::default();
         let waker = socket_state.handle();
         let internal_rpc = InternalRPC::new(executor.clone(), waker.clone());


### PR DESCRIPTION
As a tokio user, I know that I'm always setting the executor/reactor values accordingly.

While 11 dependencies seems small in the grand scheme of things, I would prefer to not need them in my dependency tree if their code paths never fire. Speeding up clean builds in CI as well as removing any potential threat models.

Making it a default feature should make this backwards compatible to most users, although if users are already using `default-features=false` this wont catch that, so I understand if this PR is rejected or postponed to a breaking major version.

Currently made the failure case panic. I'm happy to make it an `Err` instead though - you've already added `non_exhaustive` to the `Error` type so that we can extend this with an appropriate error.

To consider: should we add a tokio feature too?