### PR TITLE
fix that hearbeat send never stops if IO loop encounters error .

### DIFF
--- a/src/io_loop.rs
+++ b/src/io_loop.rs
@@ -161,7 +161,8 @@ impl IoLoop {
                     let mut writable_context = Context::from_waker(&writable_waker);
                     while self.should_continue() {
                         if let Err(err) = self.run(&mut readable_context, &mut writable_context) {
-                            self.critical_error(err)?;
+                            let _ = self.critical_error(err);
+                            break;
                         }
                     }
                     self.internal_rpc.stop();


### PR DESCRIPTION
Refered to #288, #187, currently connection error in lapin is to using "on_error" hook callback and create new connection instance then drop the old one, while i found that even the new connetion instance is recreated, the old instance's heart beat is never stopped.
It took me a few days to dig inside and i think the PR shows a logic flaw that heartbeat cancel is actually never called properly .