### PR TITLE
Don't try to close a connection that is in an error state

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -249,7 +249,17 @@ impl Connection {
         &self.status
     }
 
+    /// Request a connection close.
+    ///
+    /// This method is only successful if the connection isn't in an error state.
+    /// Otherwise, [`InvalidConnectionState`] error is returned.
+    ///
+    /// [`InvalidConnectionState`]: ./enum.Error.html#variant.InvalidConnectionState
     pub async fn close(&self, reply_code: ReplyCode, reply_text: &str) -> Result<()> {
+        if self.status.errored() {
+            return Err(Error::InvalidConnectionState(self.status.state()));
+        }
+
         self.channels.set_connection_closing();
         if let Some(channel0) = self.channels.get(0) {
             channel0

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -251,12 +251,12 @@ impl Connection {
 
     /// Request a connection close.
     ///
-    /// This method is only successful if the connection isn't in an error state.
-    /// Otherwise, [`InvalidConnectionState`] error is returned.
+    /// This method is only successful if the connection is in the connected state,
+    /// otherwise an [`InvalidConnectionState`] error is returned.
     ///
     /// [`InvalidConnectionState`]: ./enum.Error.html#variant.InvalidConnectionState
     pub async fn close(&self, reply_code: ReplyCode, reply_text: &str) -> Result<()> {
-        if self.status.errored() {
+        if !self.status.connected() {
             return Err(Error::InvalidConnectionState(self.status.state()));
         }
 


### PR DESCRIPTION
If a client try to gracefully shutdown when it encounter an error it can, potentially, wait forever for a reply to the `connection::close()` method. We see that a lot in our test environment where we kill services in arbitrary order to see if they can recover automatically.

 So this commit try to mitigate that.