### PR TITLE
Correctly check the max channel limit

### DIFF
--- a/src/id_sequence.rs
+++ b/src/id_sequence.rs
@@ -64,7 +64,7 @@ impl<
 
     fn check_max(&self) -> bool {
         if let Some(max) = self.max {
-            self.id <= max
+            self.id < max
         } else {
             true
         }


### PR DESCRIPTION
We noticed that opening many channels while having the max as a u16::MAX makes lapin crash

I've added a test `channel_limit` that without the next commit panics