### PR TITLE
io_loop: Propagate current tracing span into io_loop thread

### DIFF
--- a/src/io_loop.rs
+++ b/src/io_loop.rs
@@ -159,10 +159,12 @@ impl IoLoop {
     pub fn start(mut self) -> Result<()> {
         let waker = self.socket_state.handle();
         let handle = self.connection_io_loop_handle.clone();
+        let current_span = tracing::Span::current();
         handle.register(
             ThreadBuilder::new()
                 .name("lapin-io-loop".to_owned())
                 .spawn(move || {
+                    let _enter = current_span.enter();
                     let readable_waker = self.readable_waker();
                     let mut readable_context = Context::from_waker(&readable_waker);
                     let writable_waker = self.writable_waker();


### PR DESCRIPTION
This change will be useful in cases where the application uses multiple AMQP connections.
Log entries like the ones below can be somewhat frustrating when investigating issues.
```
msg="error doing IO" error="IOError(Os { code: 110, kind: TimedOut, message: \"Connection timed out\" })"  target=lapin::io_loop
msg="error doing IO" error="IOError(Os { code: 113, kind: HostUnreachable, message: \"No route to host\" })"  target=lapin::io_loop
```
Together with this PR https://github.com/amqp-rs/executor-trait/pull/3, this will allow categorizing all log events by AMQP connections.
# Usage example
```
    use tracing_futures::Instrument;
    let conn1_span = tracing::info_span!("conn1", id = 1);
    let conn2_span = tracing::info_span!("conn2", id = 2);
    let conn1 = async {
        let options = ConnectionProperties::default()
            .with_executor(tokio_executor_trait::Tokio::current().with_current_span())
            .with_reactor(tokio_reactor_trait::Tokio);
        let uri = AMQPUri::from_str("amqp://****").unwrap();
        lapin::Connection::connect_uri(uri, options).await
    }.instrument(conn1_span).await;
    let conn2 = async {
        let options = ConnectionProperties::default()
            .with_executor(tokio_executor_trait::Tokio::current().with_current_span())
            .with_reactor(tokio_reactor_trait::Tokio);
        let uri = AMQPUri::from_str("amqp://****").unwrap();
        lapin::Connection::connect_uri(uri, options).await
    }.instrument(conn2_span).await;
```