### PR TITLE
Added mock function for testing reasons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 .env
+.idea

--- a/src/acker.rs
+++ b/src/acker.rs
@@ -35,6 +35,17 @@ impl Acker {
         }
     }
 
+    pub fn mock() -> Self {
+        Self {
+            channel_id: 0,
+            delivery_tag: 0,
+            internal_rpc: None,
+            error: None,
+            killswitch: Default::default(),
+            channel_killswitch: Default::default(),
+        }
+    }
+
     pub async fn ack(&self, options: BasicAckOptions) -> Result<bool> {
         self.rpc(|internal_rpc, resolver| {
             internal_rpc.basic_ack(


### PR DESCRIPTION
#439 

At this moment `Delivery` struct exposed, and after removing `Acker::default` needed alternative way for creation acker in tests.

Proposal:
```rust
Delivery {
    ...
    acker: Acker::mock()
}