### PR TITLE
connection_status deadlock on poisoning connection

### DIFF
--- a/src/connection_status.rs
+++ b/src/connection_status.rs
@@ -112,7 +112,8 @@ impl ConnectionStatus {
     }
 
     pub(crate) fn poison(&self, err: Error) {
-        if let Some((resolver, _connection)) = self.lock_inner().poison(err.clone()) {
+        let resolver = self.lock_inner().poison(err.clone());
+        if let Some((resolver, _connection)) = resolver {
             // We perform the reject here to drop the lock() above before dropping the Connection
             resolver.reject(err);
         }


### PR DESCRIPTION
If a connection fails, the IoLoop attempts to poison it, unfortunately the current implementation causes a deadlock.

This change refactors the poison call to explicitly drop the lock before the connection.