### PR TITLE
Implement Debug for ConnectionBuilder

### DIFF
--- a/src/connection_builder.rs
+++ b/src/connection_builder.rs
@@ -6,6 +6,7 @@ use crate::{
 use async_rs::{Runtime, traits::*};
 use std::io;
 
+#[derive(Debug)]
 pub struct ConnectionBuilder<RK: RuntimeKit + Send + Sync + Clone + 'static> {
     runtime: Runtime<RK>,
     uri: UriBuilder,
@@ -14,7 +15,7 @@ pub struct ConnectionBuilder<RK: RuntimeKit + Send + Sync + Clone + 'static> {
 }
 pub type DefaultConnectionBuilder = ConnectionBuilder<runtime::DefaultRuntimeKit>;
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 enum UriBuilder {
     Str(String),
     Uri(AMQPUri),

--- a/src/connection_properties.rs
+++ b/src/connection_properties.rs
@@ -3,6 +3,7 @@ use crate::{
     types::{AMQPValue, FieldTable, LongString, ShortString},
 };
 use backon::ExponentialBuilder;
+use std::fmt;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -67,5 +68,16 @@ impl ConnectionProperties {
     pub fn enable_auto_recover(mut self) -> Self {
         self.auto_recover = true;
         self
+    }
+}
+
+impl fmt::Debug for ConnectionProperties {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConnectionProperties")
+            .field("locale", &self.locale)
+            .field("client_properties", &self.client_properties)
+            .field("backoff", &self.backoff)
+            .field("auto_recover", &self.auto_recover)
+            .finish()
     }
 }


### PR DESCRIPTION
All of the bb8 implementations implement Debug, and this seems useful to allow the set up properties to be inspected for `ConnectionProperties` and `ConnectionBuilder`.