### PR TITLE
Update aws-lc-sys and rustls-webpki to fix security vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -345,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -1969,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- **aws-lc-sys** 0.38.0 → 0.39.1 — fixes [RUSTSEC-2026-0044](https://rustsec.org/advisories/RUSTSEC-2026-0044.html) (X.509 Name Constraints Bypass) and [RUSTSEC-2026-0048](https://rustsec.org/advisories/RUSTSEC-2026-0048.html) (CRL Distribution Point Scope Check Logic Error)
- **rustls-webpki** 0.103.9 → 0.103.10 — fixes [RUSTSEC-2026-0049](https://rustsec.org/advisories/RUSTSEC-2026-0049.html) (CRLs not considered authoritative by Distribution Point)

## Test plan
- [ ] CI passes with updated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)